### PR TITLE
added missing line to pass colors to Arcs components

### DIFF
--- a/lib/src/DonutChart.js
+++ b/lib/src/DonutChart.js
@@ -118,6 +118,7 @@ export default class DonutChart extends Component {
             viewBox={`0 0 ${width} ${height}`}>
             <Arcs
                 className={ arcsClassName }
+                colors={ colors }
                 data={ checkData }
                 width={ graphWidth }
                 emptyColor={ emptyColor }


### PR DESCRIPTION
Passing an array of colors for the "colors" prop of DonutChart isn't working because they aren't being passed on to Arcs elements. This fixes it.